### PR TITLE
[SERVICES-226] Extend api client response

### DIFF
--- a/apiclient/apiclient.go
+++ b/apiclient/apiclient.go
@@ -22,7 +22,7 @@ func NewClient(baseURL string) (*Client, error) {
 	return client, nil
 }
 
-func (client *Client) Call(method, endpoint string, data url.Values) ([]byte, error) {
+func (client *Client) Call(method, endpoint string, data url.Values) (*http.Response, error) {
 	request, err := client.NewRequest(method, endpoint, data)
 	if err != nil {
 		return nil, err
@@ -32,14 +32,8 @@ func (client *Client) Call(method, endpoint string, data url.Values) ([]byte, er
 	if err != nil {
 		return nil, err
 	}
-	defer response.Body.Close()
 
-	body, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	return body, nil
+	return response, nil
 }
 
 func (client *Client) NewRequest(method, endpoint string, data url.Values) (*http.Request, error) {
@@ -58,4 +52,15 @@ func (client *Client) NewRequest(method, endpoint string, data url.Values) (*htt
 	request.Header.Add("Content-Length", strconv.Itoa(len(data.Encode())))
 
 	return request, nil
+}
+
+func (client *Client) GetBody(resp *http.Response) ([]byte, error) {
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return body, nil
 }

--- a/phalanx/phalanx.go
+++ b/phalanx/phalanx.go
@@ -31,7 +31,12 @@ func (client *Client) Check(checkType, content string) (bool, error) {
 	data.Add(typeKey, checkType)
 	data.Add(contentKey, content)
 
-	resBody, err := client.apiClient.Call("POST", checkEndpoint, data)
+	resp, err := client.apiClient.Call("POST", checkEndpoint, data)
+	if err != nil {
+		return false, err
+	}
+
+	resBody, err := client.apiClient.GetBody(resp)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
We need to return full response on api client call, to have access to various response fields. Reading body response will be now done separately.

Take a look: @jcellary & @pchojnacki 