### PR TITLE
Add the connection close header to the request

### DIFF
--- a/apiclient/apiclient.go
+++ b/apiclient/apiclient.go
@@ -28,6 +28,11 @@ func (client *Client) Call(method, endpoint string, data url.Values) (*http.Resp
 		return nil, err
 	}
 
+	// This seems heavy handed but as a rule we are closing the connection after
+	// GetBody below. This ensures that we are communicating our intentions in
+	// the HTTP request.
+	request.Close = true
+
 	response, err := client.httpClient.Do(request)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Communicate to the other end of the API client that we will be closing the connection. If we don't then subsequent request might fail with a connection reset by peer error or an EOF.

This should be harmless. Whenever we [get the body via this interface we are always closing the connection](https://github.com/Wikia/go-commons/blob/master/apiclient/apiclient.go#L58).

/cc @nmonterroso @ArturKlajnerok 