### PR TITLE
Proof of concept service resolver interface

### DIFF
--- a/consul/mocks.go
+++ b/consul/mocks.go
@@ -5,11 +5,11 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-type MockedConsulCatalogAPI struct {
+type MockedConsulHealthAPI struct {
 	mock.Mock
 }
 
-func (m *MockedConsulCatalogAPI) Service(service, tag string, q *api.QueryOptions) ([]*api.CatalogService, *api.QueryMeta, error) {
-	args := m.Called(service, tag, q)
-	return args.Get(0).([]*api.CatalogService), args.Get(1).(*api.QueryMeta), args.Error(2)
+func (m *MockedConsulHealthAPI) Service(service, tag string, passingOnly bool, q *api.QueryOptions) ([]*api.ServiceEntry, *api.QueryMeta, error) {
+	args := m.Called(service, tag, passingOnly, q)
+	return args.Get(0).([]*api.ServiceEntry), args.Get(1).(*api.QueryMeta), args.Error(2)
 }

--- a/consul/mocks.go
+++ b/consul/mocks.go
@@ -1,0 +1,15 @@
+package consul
+
+import (
+	"github.com/hashicorp/consul/api"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockedConsulCatalogAPI struct {
+	mock.Mock
+}
+
+func (m *MockedConsulCatalogAPI) Service(service, tag string, q *api.QueryOptions) ([]*api.CatalogService, *api.QueryMeta, error) {
+	args := m.Called(service, tag, q)
+	return args.Get(0).([]*api.CatalogService), args.Get(1).(*api.QueryMeta), args.Error(2)
+}

--- a/consul/resolver.go
+++ b/consul/resolver.go
@@ -8,7 +8,8 @@ import (
 )
 
 type ConsulCatalogAPI interface {
-	Service(service, tag string, q *api.QueryOptions) ([]*api.CatalogService, *api.QueryMeta, error)
+	Service(service, tag string, passingOnly bool, q *api.QueryOptions) ([]*api.ServiceEntry,
+		*api.QueryMeta, error)
 }
 
 type AddressTuple struct {
@@ -17,8 +18,9 @@ type AddressTuple struct {
 }
 
 type ConsulResolver interface {
-	FindAll(name, tag string) (*[]AddressTuple, error)
+	ResolveAll(name, tag string) ([]*AddressTuple, error)
 	Resolve(name, tag string) (*AddressTuple, error)
+	ResolveAddress(name, tag string) (string, error)
 }
 
 type ConsulResolverValue struct {
@@ -29,19 +31,41 @@ func NewResolver(consulAPIClient ConsulCatalogAPI) *ConsulResolverValue {
 	return &ConsulResolverValue{consulAPIClient}
 }
 
-func (resolver *ConsulResolverValue) FindAll(name, tag string) ([]*AddressTuple, error) {
-	return make([]*AddressTuple, 0), nil
+func (resolver *ConsulResolverValue) ResolveAll(name, tag string) ([]*AddressTuple, error) {
+	services, _, err := resolver.consulAPIClient.Service(name, tag, true, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	tuples := make([]*AddressTuple, len(services))
+	for index, service := range services {
+		tuples[index] = &AddressTuple{service.Node.Address, service.Service.Port}
+	}
+
+	return tuples, nil
 }
 
 func (resolver *ConsulResolverValue) Resolve(name, tag string) (*AddressTuple, error) {
-	services, err := resolver.FindAll(name, tag)
+	services, err := resolver.ResolveAll(name, tag)
 	if err != nil {
 		return nil, err
 	}
 
 	if services != nil && len(services) < 1 {
-		return nil, fmt.Errorf("error, empty service list for %q with tag %q", name, tag)
+		return nil, fmt.Errorf("error, no services available for %q with tag %q", name, tag)
 	}
 
 	return services[rand.Intn(len(services))], nil
+}
+
+func (resolver *ConsulResolverValue) ResolveAddress(name, tag string) (string, error) {
+	return "", nil
+}
+
+func (t *AddressTuple) ToAddress() string {
+	if t != nil {
+		return fmt.Sprintf("http://%s:%d", t.Address, t.Port)
+	}
+
+	return ""
 }

--- a/consul/resolver.go
+++ b/consul/resolver.go
@@ -1,0 +1,47 @@
+package consul
+
+import (
+	"fmt"
+	"math/rand"
+
+	"github.com/hashicorp/consul/api"
+)
+
+type ConsulCatalogAPI interface {
+	Service(service, tag string, q *api.QueryOptions) ([]*api.CatalogService, *api.QueryMeta, error)
+}
+
+type AddressTuple struct {
+	Address string
+	Port    int
+}
+
+type ConsulResolver interface {
+	FindAll(name, tag string) (*[]AddressTuple, error)
+	Resolve(name, tag string) (*AddressTuple, error)
+}
+
+type ConsulResolverValue struct {
+	consulAPIClient ConsulCatalogAPI
+}
+
+func NewResolver(consulAPIClient ConsulCatalogAPI) *ConsulResolverValue {
+	return &ConsulResolverValue{consulAPIClient}
+}
+
+func (resolver *ConsulResolverValue) FindAll(name, tag string) ([]*AddressTuple, error) {
+	return make([]*AddressTuple, 0), nil
+}
+
+func (resolver *ConsulResolverValue) Resolve(name, tag string) (*AddressTuple, error) {
+	services, err := resolver.FindAll(name, tag)
+	if err != nil {
+		return nil, err
+	}
+
+	if services != nil && len(services) < 1 {
+		return nil, fmt.Errorf("error, empty service list for %q with tag %q", name, tag)
+	}
+
+	return services[rand.Intn(len(services))], nil
+}

--- a/consul/resolver.go
+++ b/consul/resolver.go
@@ -20,7 +20,7 @@ type AddressTuple struct {
 type ConsulResolver interface {
 	ResolveAll(name, tag string) ([]*AddressTuple, error)
 	Resolve(name, tag string) (*AddressTuple, error)
-	ResolveAddress(name, tag string) (string, error)
+	ResolveURI(name, tag string) (string, error)
 }
 
 type ConsulResolverValue struct {
@@ -68,16 +68,16 @@ func (resolver *ConsulResolverValue) Resolve(name, tag string) (*AddressTuple, e
 	return services[rand.Intn(len(services))], nil
 }
 
-func (resolver *ConsulResolverValue) ResolveAddress(name, tag string) (string, error) {
+func (resolver *ConsulResolverValue) ResolveURI(name, tag string) (string, error) {
 	tuple, err := resolver.Resolve(name, tag)
 	if err != nil {
 		return "", err
 	}
 
-	return tuple.ToAddress(), nil
+	return tuple.ToURI(), nil
 }
 
-func (t *AddressTuple) ToAddress() string {
+func (t *AddressTuple) ToURI() string {
 	if t != nil {
 		return fmt.Sprintf("http://%s:%d", t.Address, t.Port)
 	}

--- a/consul/resolver_test.go
+++ b/consul/resolver_test.go
@@ -1,28 +1,62 @@
 package consul
 
 import (
+	"math/rand"
 	"testing"
 
+	"github.com/hashicorp/consul/api"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 )
 
-func TestFindAll(t *testing.T) {
-	catalog := new(MockedConsulCatalogAPI)
-	resolver := NewResolver(catalog)
-
-	services, err := resolver.FindAll("auth", "production")
-	assert.Equal(t, 2, len(services), "we did not receive 2 nodes")
-	assert.Equal(t, "10.10.10.10", services[0].Address, "unexpected ip")
-	assert.Equal(t, 9500, services[0].Port, "unexpected port")
-	assert.Nil(t, err)
+type ResolverTestSuite struct {
+	suite.Suite
+	consul   *MockedConsulHealthAPI
+	resolver ConsulResolver
+	response []*api.ServiceEntry
 }
 
-func TestResolve(t *testing.T) {
-	catalog := new(MockedConsulCatalogAPI)
-	resolver := NewResolver(catalog)
+func (suite *ResolverTestSuite) SetupTest() {
+	rand.Seed(2)
+	suite.consul = new(MockedConsulHealthAPI)
+	suite.resolver = NewResolver(suite.consul)
 
-	service, err := resolver.Resolve("auth", "production")
-	assert.Equal(t, "10.10.10.10", service.Address, "unexpected ip")
-	assert.Equal(t, 9500, service.Port, "unexpected port")
-	assert.Nil(t, err)
+	suite.response = make([]*api.ServiceEntry, 2)
+	suite.response[0] = &api.ServiceEntry{&api.Node{"foo", "10.10.10.10"},
+		&api.AgentService{"1234", "auth", []string{"production"}, 9500, ""},
+		nil}
+	suite.response[1] = &api.ServiceEntry{&api.Node{"bar", "10.10.10.11"},
+		&api.AgentService{"1234", "auth", []string{"production"}, 9500, ""},
+		nil}
+}
+
+func (suite *ResolverTestSuite) TestResolveAll() {
+	suite.consul.On("Service", "auth", "production", true,
+		(*api.QueryOptions)(nil)).Return(suite.response,
+		(*api.QueryMeta)(nil), nil)
+	services, err := suite.resolver.ResolveAll("auth", "production")
+	assert.Equal(suite.T(), 2, len(services), "we did not receive 2 nodes")
+	assert.Equal(suite.T(), "10.10.10.10", services[0].Address, "unexpected ip")
+	assert.Equal(suite.T(), 9500, services[0].Port, "unexpected port")
+	assert.Nil(suite.T(), err)
+}
+
+func (suite *ResolverTestSuite) TestResolve() {
+	suite.consul.On("Service", "auth", "production", true,
+		(*api.QueryOptions)(nil)).Return(suite.response,
+		(*api.QueryMeta)(nil), nil)
+	service, err := suite.resolver.Resolve("auth", "production")
+	assert.Equal(suite.T(), "10.10.10.10", service.Address, "unexpected ip")
+	assert.Equal(suite.T(), 9500, service.Port, "unexpected port")
+	assert.Nil(suite.T(), err)
+}
+
+func TestResolverTestSuite(t *testing.T) {
+	suite.Run(t, new(ResolverTestSuite))
+}
+
+func TestAddressTupleToAddress(t *testing.T) {
+	tuple := &AddressTuple{"10.10.10.10", 80}
+	address := tuple.ToAddress()
+	assert.Equal(t, "http://10.10.10.10:80", address, "error, malformed address")
 }

--- a/consul/resolver_test.go
+++ b/consul/resolver_test.go
@@ -34,7 +34,7 @@ func (suite *ResolverTestSuite) TestResolveAll() {
 	suite.consul.On("Service", "auth", "production", true,
 		&api.QueryOptions{AllowStale: true}).Return(suite.response,
 		(*api.QueryMeta)(nil), nil)
-	services, err := suite.resolver.ResolveAll("auth", "production", true)
+	services, err := suite.resolver.ResolveAll("auth", "production")
 	assert.Equal(suite.T(), 2, len(services), "we did not receive 2 nodes")
 	assert.Equal(suite.T(), "10.10.10.10", services[0].Address, "unexpected ip")
 	assert.Equal(suite.T(), 9500, services[0].Port, "unexpected port")
@@ -45,7 +45,7 @@ func (suite *ResolverTestSuite) TestResolve() {
 	suite.consul.On("Service", "auth", "production", true,
 		&api.QueryOptions{AllowStale: true}).Return(suite.response,
 		(*api.QueryMeta)(nil), nil)
-	service, err := suite.resolver.Resolve("auth", "production", true)
+	service, err := suite.resolver.Resolve("auth", "production")
 	assert.Equal(suite.T(), "10.10.10.10", service.Address, "unexpected ip")
 	assert.Equal(suite.T(), 9500, service.Port, "unexpected port")
 	assert.Nil(suite.T(), err)

--- a/consul/resolver_test.go
+++ b/consul/resolver_test.go
@@ -1,0 +1,28 @@
+package consul
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFindAll(t *testing.T) {
+	catalog := new(MockedConsulCatalogAPI)
+	resolver := NewResolver(catalog)
+
+	services, err := resolver.FindAll("auth", "production")
+	assert.Equal(t, 2, len(services), "we did not receive 2 nodes")
+	assert.Equal(t, "10.10.10.10", services[0].Address, "unexpected ip")
+	assert.Equal(t, 9500, services[0].Port, "unexpected port")
+	assert.Nil(t, err)
+}
+
+func TestResolve(t *testing.T) {
+	catalog := new(MockedConsulCatalogAPI)
+	resolver := NewResolver(catalog)
+
+	service, err := resolver.Resolve("auth", "production")
+	assert.Equal(t, "10.10.10.10", service.Address, "unexpected ip")
+	assert.Equal(t, 9500, service.Port, "unexpected port")
+	assert.Nil(t, err)
+}

--- a/consul/resolver_test.go
+++ b/consul/resolver_test.go
@@ -55,8 +55,8 @@ func TestResolverTestSuite(t *testing.T) {
 	suite.Run(t, new(ResolverTestSuite))
 }
 
-func TestAddressTupleToAddress(t *testing.T) {
+func TestAddressTupleToURI(t *testing.T) {
 	tuple := &AddressTuple{"10.10.10.10", 80}
-	address := tuple.ToAddress()
+	address := tuple.ToURI()
 	assert.Equal(t, "http://10.10.10.10:80", address, "error, malformed address")
 }

--- a/consul/resolver_test.go
+++ b/consul/resolver_test.go
@@ -32,9 +32,9 @@ func (suite *ResolverTestSuite) SetupTest() {
 
 func (suite *ResolverTestSuite) TestResolveAll() {
 	suite.consul.On("Service", "auth", "production", true,
-		(*api.QueryOptions)(nil)).Return(suite.response,
+		&api.QueryOptions{AllowStale: true}).Return(suite.response,
 		(*api.QueryMeta)(nil), nil)
-	services, err := suite.resolver.ResolveAll("auth", "production")
+	services, err := suite.resolver.ResolveAll("auth", "production", true)
 	assert.Equal(suite.T(), 2, len(services), "we did not receive 2 nodes")
 	assert.Equal(suite.T(), "10.10.10.10", services[0].Address, "unexpected ip")
 	assert.Equal(suite.T(), 9500, services[0].Port, "unexpected port")
@@ -43,9 +43,9 @@ func (suite *ResolverTestSuite) TestResolveAll() {
 
 func (suite *ResolverTestSuite) TestResolve() {
 	suite.consul.On("Service", "auth", "production", true,
-		(*api.QueryOptions)(nil)).Return(suite.response,
+		&api.QueryOptions{AllowStale: true}).Return(suite.response,
 		(*api.QueryMeta)(nil), nil)
-	service, err := suite.resolver.Resolve("auth", "production")
+	service, err := suite.resolver.Resolve("auth", "production", true)
 	assert.Equal(suite.T(), "10.10.10.10", service.Address, "unexpected ip")
 	assert.Equal(suite.T(), 9500, service.Port, "unexpected port")
 	assert.Nil(suite.T(), err)


### PR DESCRIPTION
This is a convenience interface on top of `consul/api` to make service resolution easier. The interface is as follows:

```go
service, err := resolver.Resolve("auth", "production")
```

`Resolve` will give you *an* ipaddress (string) and port (integer) tuple that can be used to construct a URL for a service end point. The ipaddress and port you are given are selected at random from the list of services matching the name and tag criteria. 

If this look ok, I'll keep going. This work is in service of connecting helios to other services https://wikia-inc.atlassian.net/browse/SERVICES-370.

/cc @Wikia/services-team 

