### PR TITLE
Add more convenient interface for config creation

### DIFF
--- a/consul/README.md
+++ b/consul/README.md
@@ -23,10 +23,11 @@ directly and inject that into `NewResolver`. Example:
 
 ```go
 import (
+	"github.com/hashicorp/consul/api"
 	"github.com/Wikia/go-commons/consul"
 )
 
-health := consul.ConsulAPIHealthClientFactory(consul.ConsulAPIConfigFactory("your.consul.service:8500"))
+health := consul.ConsulAPIHealthClientFactory(api.DefaultConfig())
 resolver := consul.NewResolver(health)
 address, _ := resolver.ResolveURI("user-preference", "production") // returns "http://10.10.10.10:12345"
 ```

--- a/consul/README.md
+++ b/consul/README.md
@@ -18,8 +18,7 @@ address, _ := resolver.ResolveURI("user-preference", "production") // returns "h
 ```
 
 The above uses some sane defaults for consul. If you need to use a different
-host other than `consul.service.consul` you can create a `Health` client
-directly and inject that into `NewResolver`. Example:
+config you can create a `Health` client directly and inject that into `NewResolver`. Example:
 
 ```go
 import (
@@ -27,9 +26,18 @@ import (
 	"github.com/Wikia/go-commons/consul"
 )
 
-health := consul.ConsulAPIHealthClientFactory(api.DefaultConfig())
+config := api.DefaultConfig()
+client, _ := api.NewClient(config)
+health := client.Health()
 resolver := consul.NewResolver(health)
 address, _ := resolver.ResolveURI("user-preference", "production") // returns "http://10.10.10.10:12345"
+```
+
+If you only need to change the consul address, you can do set the following
+environment variable and use `NewDefaultResolver()`:
+
+```
+export CONSUL_HTTP_ADDR=consul.service.consul:8500
 ```
 
 See the package for more details regarding the configuration.

--- a/consul/README.md
+++ b/consul/README.md
@@ -23,14 +23,10 @@ directly and inject that into `NewResolver`. Example:
 
 ```go
 import (
-	"github.com/hashicorp/consul/api"
 	"github.com/Wikia/go-commons/consul"
 )
 
-config := api.DefaultConfig()
-config.Address = "your.consul.server:8500"
-client, _ := api.NewClient(config)
-health := client.Health()
+health := consul.ConsulAPIHealthClientFactory(consul.ConsulAPIConfigFactory("your.consul.service:8500"))
 resolver := consul.NewResolver(health)
 address, _ := resolver.ResolveURI("user-preference", "production") // returns "http://10.10.10.10:12345"
 ```

--- a/consul/resolver.go
+++ b/consul/resolver.go
@@ -32,12 +32,20 @@ func NewResolver(consulAPIClient ConsulCatalogAPI) *ConsulResolverValue {
 	return &ConsulResolverValue{consulAPIClient, true}
 }
 
-func DefaultResolver() *ConsulResolverValue {
+func ConsulAPIConfigFactory(address string) *api.Config {
 	config := api.DefaultConfig()
-	config.Address = "consul.service.consul:8500"
+	config.Address = address
+	return config
+}
+
+func ConsulAPIHealthClientFactory(config *api.Config) *api.Health {
 	client, _ := api.NewClient(config)
-	health := client.Health()
-	return &ConsulResolverValue{health, true}
+	return client.Health()
+}
+
+func DefaultResolver() *ConsulResolverValue {
+	health := ConsulAPIHealthClientFactory(ConsulAPIConfigFactory("consul.service.consul:8500"))
+	return NewResolver(health)
 }
 
 func (resolver *ConsulResolverValue) ResolveAll(name, tag string) ([]*AddressTuple, error) {

--- a/consul/resolver.go
+++ b/consul/resolver.go
@@ -44,7 +44,7 @@ func ConsulAPIHealthClientFactory(config *api.Config) *api.Health {
 }
 
 func DefaultResolver() *ConsulResolverValue {
-	health := ConsulAPIHealthClientFactory(ConsulAPIConfigFactory("consul.service.consul:8500"))
+	health := ConsulAPIHealthClientFactory(ConsulAPIConfigFactory("localhost:8500"))
 	return NewResolver(health)
 }
 

--- a/consul/resolver.go
+++ b/consul/resolver.go
@@ -32,19 +32,13 @@ func NewResolver(consulAPIClient ConsulCatalogAPI) *ConsulResolverValue {
 	return &ConsulResolverValue{consulAPIClient, true}
 }
 
-func ConsulAPIConfigFactory(address string) *api.Config {
-	config := api.DefaultConfig()
-	config.Address = address
-	return config
-}
-
 func ConsulAPIHealthClientFactory(config *api.Config) *api.Health {
 	client, _ := api.NewClient(config)
 	return client.Health()
 }
 
 func DefaultResolver() *ConsulResolverValue {
-	health := ConsulAPIHealthClientFactory(ConsulAPIConfigFactory("localhost:8500"))
+	health := ConsulAPIHealthClientFactory(api.DefaultConfig())
 	return NewResolver(health)
 }
 


### PR DESCRIPTION
This PR provides a more convenient interface for creating the `api.Health` object and injecting it. For example, you can now do:

```go
health := consul.ConsulAPIHealthClientFactory(consul.ConsulAPIConfigFactory("your.consul.service:8500"))
resolver := consul.NewResolver(health)
address, _ := resolver.ResolveURI("user-preference", "production") // returns "http://10.10.10.10:12345"
```

To create a custom config and inject the `Health` object.

/cc @Wikia/services-team @sqreek 