### PR TITLE
Properly invoke ApiClient.Call() (no headers).

### DIFF
--- a/phalanx/phalanx.go
+++ b/phalanx/phalanx.go
@@ -48,7 +48,7 @@ func (client *Client) Check(checkType, content string) (bool, error) {
 	data.Add(typeKey, checkType)
 	data.Add(contentKey, content)
 
-	resp, err := client.apiClient.Call("POST", checkEndpoint, data)
+	resp, err := client.apiClient.Call("POST", checkEndpoint, data, map[string]string{})
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
Updated call too ApiClient.

@Wikia/services-team 