### PR TITLE
Add the phalanx /match RPC endpoint

### DIFF
--- a/phalanx/phalanx.go
+++ b/phalanx/phalanx.go
@@ -1,24 +1,39 @@
 package phalanx
 
 import (
-	"net/url"
-
+	"encoding/json"
 	"github.com/Wikia/go-commons/apiclient"
+	"net/url"
 )
 
 const (
 	contentKey     = "content"
 	typeKey        = "type"
 	checkEndpoint  = "check"
+	matchEndpoint  = "match"
 	checkOk        = "ok\n"
 	checkTypeName  = "user"
 	checkTypeEmail = "email"
 )
 
+type MatchRecord struct {
+	Regex         bool   `json:"regex"`
+	Expires       string `json:"expires"`
+	Text          string `json:"text"`
+	Reason        string `json:"reason"`
+	Exact         bool   `json:"exact"`
+	CaseSensitive bool   `json:"caseSensative"`
+	Id            int    `json:"id"`
+	Language      string `json:"language"`
+	AuthorId      int    `json:"authorId"`
+	Type          int    `json:"type"`
+}
+
 type PhalanxClient interface {
 	CheckName(name string) (bool, error)
 	CheckEmail(email string) (bool, error)
 	Check(checkType, content string) (bool, error)
+	Match(matchType, content string) ([]MatchRecord, error)
 }
 
 type Client struct {
@@ -63,4 +78,29 @@ func (client *Client) Check(checkType, content string) (bool, error) {
 	}
 
 	return false, nil
+}
+
+func (client *Client) Match(checkType, content string) ([]MatchRecord, error) {
+	response := make([]MatchRecord, 0)
+
+	data := url.Values{}
+	data.Add(typeKey, checkType)
+	data.Add(contentKey, content)
+
+	resp, err := client.apiClient.Call("POST", matchEndpoint, data, map[string]string{})
+	if err != nil {
+		return nil, err
+	}
+
+	resBody, err := client.apiClient.GetBody(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal(resBody, &response)
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
 }


### PR DESCRIPTION
Add the phalanx /match RPC endpoint as the Match method. The request takes the form:

```
$ curl -v -d"type=user&content=Dante1011" -X POST  http://phalanx.service.sjc.consul:4666/match
[{"regex" : false, "expires" : "", "text" : "Dante1011", "reason" : "傀儡账户", "exact" : false, "caseSensitive" : false, "id" : 160658, "language" : "", "authorId" : 11909873, "type" : 8}]
```

The documentation for unmarshalling JSON arrays of objects is not very clear. You first have to create an empty array and then pass that as a reference to `Unmarshal`. Creating a type that is an array of the same form doesn't work as you might expect.

https://wikia-inc.atlassian.net/browse/SERVICES-1085

@Wikia/services-team 

