### PR TITLE
(PLATFORM-2590) Add retries to Helios's Phalanx client

### DIFF
--- a/apiclient/apiclient.go
+++ b/apiclient/apiclient.go
@@ -8,6 +8,12 @@ import (
 	"strconv"
 )
 
+type ApiClient interface {
+	Call(method, endpoint string, data url.Values, headers map[string]string) (*http.Response, error)
+	NewRequest(method, endpoint string, data url.Values) (*http.Request, error)
+	GetBody(resp *http.Response) ([]byte, error)
+}
+
 type Client struct {
 	httpClient *http.Client
 	BaseURL    *url.URL

--- a/phalanx/mocks.go
+++ b/phalanx/mocks.go
@@ -1,0 +1,27 @@
+package phalanx
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type ApiClientMock struct {
+	mock.Mock
+}
+
+func (m *ApiClientMock) Call(method, endpoint string, data url.Values, headers map[string]string) (*http.Response, error) {
+	args := m.Called(method, endpoint, data, headers)
+	return args.Get(0).(*http.Response), args.Error(1)
+}
+
+func (m *ApiClientMock) NewRequest(method, endpoint string, data url.Values) (*http.Request, error) {
+	args := m.Called(method, endpoint, data)
+	return args.Get(0).(*http.Request), args.Error(1)
+}
+
+func (m *ApiClientMock) GetBody(resp *http.Response) ([]byte, error) {
+	args := m.Called(resp)
+	return args.Get(0).([]byte), args.Error(1)
+}

--- a/phalanx/phalanx_test.go
+++ b/phalanx/phalanx_test.go
@@ -1,0 +1,77 @@
+package phalanx
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/Wikia/go-commons/tracing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"golang.org/x/net/context"
+)
+
+type PhalanxTestSuite struct {
+	suite.Suite
+	ctx           context.Context
+	requestData   url.Values
+	httpResponse  *http.Response
+	apiClientMock *ApiClientMock
+	phalanxClient PhalanxClient
+}
+
+func (suite *PhalanxTestSuite) SetupTest() {
+	suite.ctx = tracing.NewTestContext()
+
+	suite.requestData = url.Values{}
+	suite.requestData.Add(typeKey, CheckTypeName)
+	suite.requestData.Add(contentKey, "SomeUserName")
+
+	suite.httpResponse = &http.Response{Status: "200"}
+
+	suite.apiClientMock = new(ApiClientMock)
+
+	suite.phalanxClient = &Client{apiClient: suite.apiClientMock}
+}
+
+func (suite *PhalanxTestSuite) TestRetriesSuccess() {
+	suite.apiClientMock.On("Call", "POST", checkEndpoint, suite.requestData,
+		tracing.GetHeadersFromContextAsMap(suite.ctx)).Return(suite.httpResponse, nil).Once()
+	suite.apiClientMock.On("GetBody", suite.httpResponse).Return([]byte(checkOk), nil).Once()
+
+	result, err := suite.phalanxClient.CheckName(suite.ctx, suite.requestData.Get(contentKey))
+
+	assert.True(suite.T(), result)
+	assert.Nil(suite.T(), err)
+	assert.True(suite.T(), suite.apiClientMock.AssertNumberOfCalls(suite.T(), "Call", 1))
+}
+
+func (suite *PhalanxTestSuite) TestRetriesFailedTwice() {
+	suite.apiClientMock.On("Call", "POST", checkEndpoint, suite.requestData,
+		tracing.GetHeadersFromContextAsMap(suite.ctx)).Return(suite.httpResponse, errors.New("error")).Twice()
+	suite.apiClientMock.On("Call", "POST", checkEndpoint, suite.requestData,
+		tracing.GetHeadersFromContextAsMap(suite.ctx)).Return(suite.httpResponse, nil).Once()
+	suite.apiClientMock.On("GetBody", suite.httpResponse).Return([]byte(checkOk), nil).Once()
+
+	result, err := suite.phalanxClient.CheckName(suite.ctx, suite.requestData.Get(contentKey))
+
+	assert.True(suite.T(), result)
+	assert.Nil(suite.T(), err)
+	assert.True(suite.T(), suite.apiClientMock.AssertNumberOfCalls(suite.T(), "Call", 3))
+}
+
+func (suite *PhalanxTestSuite) TestRetriesFailed() {
+	suite.apiClientMock.On("Call", "POST", checkEndpoint, suite.requestData,
+		tracing.GetHeadersFromContextAsMap(suite.ctx)).Return(suite.httpResponse, errors.New("error"))
+
+	result, err := suite.phalanxClient.CheckName(suite.ctx, suite.requestData.Get(contentKey))
+
+	assert.False(suite.T(), result)
+	assert.NotNil(suite.T(), err)
+	assert.True(suite.T(), suite.apiClientMock.AssertNumberOfCalls(suite.T(), "Call", 3))
+}
+
+func TestPhalanxTestSuite(t *testing.T) {
+	suite.Run(t, new(PhalanxTestSuite))
+}


### PR DESCRIPTION
Add retries to Helios's Phalanx client to match the retries employed
by MediaWiki's Phalanx client.

Implements the logic from [PhalanxService.class.php](https://github.com/Wikia/app/blob/3de9dfa3dc3c4/extensions/wikia/PhalanxII/services/PhalanxService.class.php#L249-L268) into Helios' client.